### PR TITLE
Update sqs-configure-sse-existing-queue.md

### DIFF
--- a/doc_source/sqs-configure-sse-existing-queue.md
+++ b/doc_source/sqs-configure-sse-existing-queue.md
@@ -4,7 +4,7 @@ Server\-side encryption \(SSE\) for Amazon SQS is available in the AWS GovCloud 
 
 **Important**  
 All requests to queues with SSE enabled must use HTTPS and [Signature Version 4](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html)\.  
-When you disable SSE, messages remain encrypted\. You must receive and decrypt a message to view its contents\.
+When you disable SSE, existing messages in the queue remain encrypted, and will still be available for clients to retrieve as long as the KMS key remains enabled and accessible\.
 
 In this tutorial you learn how to enable, disable, and configure SSE for an existing Amazon SQS queue\.
 


### PR DESCRIPTION
Hi, 

Testing shows that if you disable encryption on a queue, existing items in the queue are still decrypted as long as the KMS key remains active (and accessible). It's feels misleading to indicate that the client should retrieve and decrypt the message, when this is not the case.

Happy to discuss options for a better description of this behaviour :-)

Thanks, 
Adam

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
