### PR TITLE
Clarify that the SQS visibility timeout maximum is relative to ReceiveMessage requests, not SendMesssage requests

### DIFF
--- a/doc_source/sqs-visibility-timeout.md
+++ b/doc_source/sqs-visibility-timeout.md
@@ -47,7 +47,7 @@ Every Amazon SQS queue has the default visibility timeout setting of 30 seconds\
 If you don't know how long it takes to process a message, create a *heartbeat* for your consumer process: Specify the initial visibility timeout \(for example, 2 minutes\) and then—as long as your consumer still works on the message—keep extending the visibility timeout by 2 minutes every minute\. 
 
 **Important**  
-The maximum visibility timeout is 12 hours from the time that Amazon SQS receives the message\. Extending the visibility timeout does not reset the 12\-hour maximum\. If your consumer needs longer than 12 hours, consider using Step Functions\. 
+The maximum visibility timeout is 12 hours from the time that Amazon SQS receives the [ReceiveMessage](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html) request\. Extending the visibility timeout does not reset the 12\-hour maximum\. If your consumer needs longer than 12 hours, consider using Step Functions\. 
 
 ## Changing the visibility timeout for a message<a name="changing-message-visibility-timeout"></a>
 

--- a/doc_source/working-with-messages.md
+++ b/doc_source/working-with-messages.md
@@ -19,7 +19,7 @@ To ensure that there is sufficient time to process messages, use one of the foll
 + If you know \(or can reasonably estimate\) how long it takes to process a message, extend the message's *visibility timeout* to the maximum time it takes to process and delete the message\. For more information, see [Configuring the Visibility Timeout](sqs-visibility-timeout.md#configuring-visibility-timeout)\.
 + If you don't know how long it takes to process a message, create a *heartbeat* for your consumer process: Specify the initial visibility timeout \(for example, 2 minutes\) and then—as long as your consumer still works on the message—keep extending the visibility timeout by 2 minutes every minute\. 
 **Important**  
-The maximum visibility timeout is 12 hours from the time that Amazon SQS receives the message\. Extending the visibility timeout does not reset the 12\-hour maximum\. If your consumer needs longer than 12 hours, consider using Step Functions\. 
+The maximum visibility timeout is 12 hours from the time that Amazon SQS receives the [ReceiveMessage](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html) request\. Extending the visibility timeout does not reset the 12\-hour maximum\. If your consumer needs longer than 12 hours, consider using Step Functions\. 
 
 ### Handling request errors<a name="handling-request-errors"></a>
 


### PR DESCRIPTION
The current language reads:
> The maximum visibility timeout is 12 hours from the time that Amazon SQS receives the message. Extending the visibility timeout does not reset the 12-hour maximum.

This is problematic, as "message" is used pervasively in the SQS documentation to refer specifically to the data plane entries stored in SQS queues, as differentiated from "request," which refers to a request intended to interact with the SQS control plane.

As written currently, it is easily misinterpreted to imply that there is a 12-hour maximum on visibility timeouts that begins when messages are _enqueued_ (i.e. "from the time that Amazon SQS receives the message"), which would mean that the message retention periods for SQS FIFOs must correspondingly be set to less than 12 hours to ensure that messages are not received and processed out of order by concurrent consumers in a race.