### PR TITLE
Update welcome.md

### DIFF
--- a/doc_source/welcome.md
+++ b/doc_source/welcome.md
@@ -1,6 +1,6 @@
 # What is Amazon Simple Queue Service?<a name="welcome"></a>
 
-Amazon Simple Queue Service \(Amazon SQS\) offers a secure, durable, and available hosted queue that lets you integrate and decouple distributed software systems and components\. Amazon SQS offers common constructs such as [dead\-letter queues](sqs-dead-letter-queues.md) and [cost allocation tags](sqs-queue-tags.md)\. It provides a generic web services API and it can be accessed by any programming language that the AWS SDK supports\.
+Amazon Simple Queue Service \(Amazon SQS\) offers a secure, durable, and available hosted queue that lets you integrate and decouple distributed software systems and components\. Amazon SQS offers common constructs such as [dead\-letter queues](sqs-dead-letter-queues.md) and [cost allocation tags](sqs-queue-tags.md)\. It provides a generic web services API that can be accessed by any programming language that the AWS SDK supports\.
 
 Amazon SQS supports both [standard](standard-queues.md) and [FIFO queues](FIFO-queues.md)\. For more information, see [Queue types](#sqs-queue-types)
 


### PR DESCRIPTION
 "and it" should be replaced with "that" in the first paragraph.  Not a big deal modification but brevity is a hallmark of AWS documentation and "that" makes more sense than "and it".

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
