### PR TITLE
Fixed minor typo

### DIFF
--- a/doc_source/using-messagededuplicationid-property.md
+++ b/doc_source/using-messagededuplicationid-property.md
@@ -8,7 +8,7 @@ Amazon SQS continues to keep track of the message deduplication ID even after th
 
 ## Providing the message deduplication ID<a name="providing-message-deduplication-id"></a>
 
-The producer should provide message deduplication ID values for each message send in the following scenarios:
+The producer should provide message deduplication ID values for each message sent in the following scenarios:
 + Messages sent with identical message bodies that Amazon SQS must treat as unique\.
 + Messages sent with identical content but different message attributes that Amazon SQS must treat as unique\.
 + Messages sent with different content \(for example, retry counts included in the message body\) that Amazon SQS must treat as duplicates\.


### PR DESCRIPTION
Fixed minor typo: "sent" vs "send". Unsure why the GitHub web-based editor (using Chrome/Mac) thought that I made changes to line 31 (I didn't) - possible bug in GitHub editor.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
