### PR TITLE
Update confirm-queue-is-empty.md

### DIFF
--- a/doc_source/confirm-queue-is-empty.md
+++ b/doc_source/confirm-queue-is-empty.md
@@ -34,7 +34,7 @@ In most cases, you can use [long polling](sqs-short-and-long-polling.md#sqs-long
 1. Observe the metrics for the following attributes:
    + `ApproximateNumberOfMessagesDelayed`
    + `ApproximateNumberOfMessagesNotVisible`
-   + `ApproximateNumberOfMessagesVisible`
+   + `ApproximateNumberOfMessages`
 
    When all of them are `0` for several minutes, the queue is empty\.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`ApproximateNumberOfMessagesVisible` is not a valid property of  `GetQueueAttributes`. I had followed this documentation whilst implementing some logic to poll SQS for final messages and kept getting errors. I had to check the SDK documentation for the language I was using (Go) and realised this was an error. This may require changes in a couple other places in the docs too.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
