### PR TITLE
Fixed the bug in AsyncMessageReceiver to make sure it works when numberOfMessagesToPrefetch is configuered as 0

### DIFF
--- a/doc_source/sqs-jms-code-examples.md
+++ b/doc_source/sqs-jms-code-examples.md
@@ -317,12 +317,12 @@ public class AsyncMessageReceiver {
         Session session = connection.createSession(false, Session.CLIENT_ACKNOWLEDGE);
         MessageConsumer consumer = session.createConsumer( session.createQueue( config.getQueueName() ) );
          
-        ReceiverCallback callback = new ReceiverCallback();
-        consumer.setMessageListener( callback );
-
         // No messages are processed until this is called
         connection.start();
          
+        ReceiverCallback callback = new ReceiverCallback();
+        consumer.setMessageListener( callback );
+
         callback.waitForOneMinuteOfSilence();
         System.out.println( "Returning after one minute of silence" );
 


### PR DESCRIPTION
The current example doesn't work when numberOfMessagesToPrefetch set to 0. This change would fix it and make sure it works regardless value of numberOfMessagesToPrefetch

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
