### PR TITLE
Be more explicit about limitations in SQS policies

### DIFF
--- a/doc_source/sqs-authentication-and-access-control.md
+++ b/doc_source/sqs-authentication-and-access-control.md
@@ -39,16 +39,6 @@ You can access AWS as any of the following types of identities:
 
 Amazon SQS has its own resource\-based permissions system that uses policies written in the same language used for AWS Identity and Access Management \(IAM\) policies\. This means that you can achieve similar things with Amazon SQS policies and IAM policies\.
 
-**Note**  
-It is important to understand that all AWS accounts can delegate their permissions to users under their accounts\. Cross\-account access allows you to share access to your AWS resources without having to manage additional users\. For information about using cross\-account access, see [Enabling Cross\-Account Access](https://docs.aws.amazon.com/IAM/latest/UserGuide/Delegation.html) in the *IAM User Guide*\.   
-Cross\-account permissions don't apply to the following actions:  
-`[AddPermission](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_AddPermission.html)`
-`[CreateQueue](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html)`
-`[DeleteQueue](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_DeleteQueue.html)`
-`[ListQueues](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ListQueues.html)`
-`[ListQueueTags](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ListQueueTags.html)`
-`[RemovePermission](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_RemovePermission.html)`
-`[SetQueueAttributes](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SetQueueAttributes.html)`
-`[TagQueue](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_TagQueue.html)`
-`[UntagQueue](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_UntagQueue.html)`
-Currently, Amazon SQS supports only a limited subset of the [condition keys available in IAM](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html#AvailableKeys)\. For more information, see [Amazon SQS API permissions: Actions and resource reference](sqs-api-permissions-reference.md)\. 
+**Note**
+It is important to understand that all AWS accounts can delegate their permissions to users under their accounts\. Cross\-account access allows you to share access to your AWS resources without having to manage additional users\. For information about using cross\-account access, see [Enabling Cross\-Account Access](https://docs.aws.amazon.com/IAM/latest/UserGuide/Delegation.html) in the *IAM User Guide*\.
+See [Limitations of Custom Policies](sqs-limitations-of-custom-policies.md) for further details on cross-account permissions and condition keys within SQS Custom Policies.

--- a/doc_source/sqs-creating-custom-policies.md
+++ b/doc_source/sqs-creating-custom-policies.md
@@ -10,4 +10,5 @@ If you want to explicitly deny or allow access based on more specific conditions
 + [Amazon SQS Access Policy Language key concepts](sqs-creating-custom-policies-key-concepts.md)
 + [Amazon SQS Access Policy Language evaluation logic](sqs-creating-custom-policies-evaluation-logic.md)
 + [Relationships between explicit and default denials in the Amazon SQS Access Policy Language](sqs-creating-custom-policies-relationships-between-explicit-default-denials.md)
++ [Limitations of Custom Policies](sqs-limitations-of-custom-policies.md)
 + [Custom Amazon SQS Access Policy Language examples](sqs-creating-custom-policies-access-policy-examples.md)

--- a/doc_source/sqs-limitations-of-custom-policies.md
+++ b/doc_source/sqs-limitations-of-custom-policies.md
@@ -1,0 +1,16 @@
+# Limitations of Custom Policies<a name="sqs-doc_source/sqs-limitations-of-custom-policies"></a>
+
+## Cross\-account Access
+Cross\-account permissions don't apply to the following actions:
+`[AddPermission](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_AddPermission.html)`
+`[CreateQueue](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html)`
+`[DeleteQueue](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_DeleteQueue.html)`
+`[ListQueues](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ListQueues.html)`
+`[ListQueueTags](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ListQueueTags.html)`
+`[RemovePermission](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_RemovePermission.html)`
+`[SetQueueAttributes](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SetQueueAttributes.html)`
+`[TagQueue](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_TagQueue.html)`
+`[UntagQueue](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_UntagQueue.html)`
+
+## Condition Keys
+Currently, Amazon SQS supports only a limited subset of the [condition keys available in IAM](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html#AvailableKeys)\. For more information, see [Amazon SQS API permissions: Actions and resource reference](sqs-api-permissions-reference.md)\.


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This PR breaks out important information about SQS policy limitations, with the intention of making the limitations more visible and explicit.

*Rationale*
Searches for policy related queries returned results directed me towards the "Using custom policies with the Amazon SQS Access Policy Language" page. This change should help others who encounter similar results, while retaining the

*Other notes*
I'm aware that this PR technically removes useful information from the "Identity and access management in Amazon SQS" page, though it _does_ provide a link to the same information. I'm not sure what the AWS documentation guidelines are on this type of change and I'm open to feedback/edits to resolve that.

