### PR TITLE
Add actions per statement limit

### DIFF
--- a/doc_source/quotas-policies.md
+++ b/doc_source/quotas-policies.md
@@ -5,6 +5,7 @@ The following table lists quotas related to policies\.
 
 | Name | Maximum | 
 | --- | --- | 
+| Actions per statement | 7 |
 | Bytes | 8,192 | 
 | Conditions | 10 | 
 | Principals | 50 | 


### PR DESCRIPTION
As noted in https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_AddPermission.html "An Amazon SQS policy can have a maximum of 7 actions." - which by itself is also not true, correct would be "An Amazon SQS policy can have a maximum of 7 actions per statement."

*Issue #, if available:*

*Description of changes:*

Adds "actions per statement" quota to docs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
