### PR TITLE
Improved FIFO DLQ Message Deduplication ID

### DIFF
--- a/doc_source/sqs-dead-letter-queues.md
+++ b/doc_source/sqs-dead-letter-queues.md
@@ -57,7 +57,7 @@ Standard queues allow a high number of in flight messages\. If the majority of y
 FIFO queues allow a lower number of in flight messages\. Thus, to keep your FIFO queue from getting blocked by a message, make sure that your application correctly handles message processing\.
 
 **Note**
-When a message is moved from a FIFO Queue to a FIFO DLQ the original messages deduplication ID will be replaced with the original messages ID. This is to make sure that the DLQ deduplication will not prevent storing of two independent messages that happen to share a deduplication id.
+When a message is moved from a FIFO queue to a FIFO DLQ, the original message's deduplication ID will be replaced with the original message's ID. This is to make sure that the DLQ deduplication will not prevent storing of two independent messages that happen to share a deduplication ID.
 
 ## When should I use a dead\-letter queue?<a name="sqs-dead-letter-queues-when-to-use"></a>
 

--- a/doc_source/sqs-dead-letter-queues.md
+++ b/doc_source/sqs-dead-letter-queues.md
@@ -56,6 +56,9 @@ Standard queues allow a high number of in flight messages\. If the majority of y
 **Note**  
 FIFO queues allow a lower number of in flight messages\. Thus, to keep your FIFO queue from getting blocked by a message, make sure that your application correctly handles message processing\.
 
+**Note**
+When a message is moved from a FIFO Queue to a FIFO DLQ the original messages deduplication ID will be replaced with the original messages ID. This is to make sure that the DLQ deduplication will not prevent storing of two independent messages that happen to share a deduplication id.
+
 ## When should I use a dead\-letter queue?<a name="sqs-dead-letter-queues-when-to-use"></a>
 
 ![\[Image NOT FOUND\]](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/images/checkmark.png)Do use dead\-letter queues with standard queues\. You should always take advantage of dead\-letter queues when your applications don't depend on ordering\. Dead\-letter queues can help you troubleshoot incorrect message transmission operations\.


### PR DESCRIPTION
This behavior is documented in https://repost.aws/questions/QUnX0CmD89TRicszg_dHj6sg/message-deduplication-id-became-the-message-id-after-being-moved-to-the-dlq

This has also been confirmed by our usage of a FIFO DLQ as well

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
